### PR TITLE
Add IRC chat to main menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,4 +105,5 @@ From the main menu you can open a simple settings application. The following opt
 * **Display → Brightness** – adjust the LCD brightness using the joystick left/right.
 * **Connections → WiFi** – scan for nearby networks and attempt to connect. Press `KEY2` to rescan.
 * **Connections → Bluetooth** – list Bluetooth devices and connect to one. Press `KEY2` to rescan.
+* **IRC Chat** – open a basic IRC client to read and send messages.
 

--- a/main_menu.py
+++ b/main_menu.py
@@ -62,6 +62,7 @@ MENU_ITEMS = [
     ("LCD Demo", "test_144_lcd.py"),
     ("Input Demo", "test_screen_buttons_joystick.py"),
     ("Snake Game", "snake_game.py"),
+    ("IRC Chat", "irc_chat.py"),
     ("Images", "images_app.py"),
     ("Settings", "settings_menu.py"),
 ]


### PR DESCRIPTION
## Summary
- hook `irc_chat.py` into the main menu list
- document IRC chat feature

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847e0ec9d2c832f85669d665410987b