### PR TITLE
Add remote server to main menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,4 +109,5 @@ From the main menu you can open a simple settings application. The following opt
   * The client connects to `irc.libera.chat` by default. You can override this
     by setting the `IRC_SERVER`, `IRC_PORT`, `IRC_CHANNEL`, or `IRC_NICK`
     environment variables before launching the program.
+* **Remote Web Server** – start a simple HTTP server for controlling the device remotely.
 

--- a/main_menu.py
+++ b/main_menu.py
@@ -63,6 +63,7 @@ MENU_ITEMS = [
     ("Input Demo", "test_screen_buttons_joystick.py"),
     ("Snake Game", "snake_game.py"),
     ("IRC Chat", "irc_chat.py"),
+    ("Remote Server", "remote_control_server.py"),
     ("Images", "images_app.py"),
     ("Settings", "settings_menu.py"),
 ]


### PR DESCRIPTION
## Summary
- link the remote web server script from the main menu
- document remote server option in README

## Testing
- `python3 -m py_compile main_menu.py remote_control_server.py images_app.py settings_menu.py irc_chat.py snake_game.py test_144_lcd.py test_screen_buttons_joystick.py`

------
https://chatgpt.com/codex/tasks/task_e_6847e5be6be0832facfe7403143823f8