### PR TITLE
Fix remote server start on Python <3.10

### DIFF
--- a/remote_control_server.py
+++ b/remote_control_server.py
@@ -9,8 +9,10 @@ import time
 import urllib.parse
 
 # Global variables for communication with the main application
+from typing import Optional
+
 remote_input_queue: queue.Queue[str] = queue.Queue()
-remote_image_request: str | None = None
+remote_image_request: Optional[str] = None
 
 # List of images available for viewing
 AVAILABLE_IMAGES: list[str] = [


### PR DESCRIPTION
## Summary
- fix TypeError from use of the `|` union when starting `remote_control_server.py`

## Testing
- `python3 -m py_compile remote_control_server.py`
- `python3 -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6847e6b5b694832fb2aff188fb69f201